### PR TITLE
Update ServeCommand to use Compose V2

### DIFF
--- a/src/ServeCommand.php
+++ b/src/ServeCommand.php
@@ -111,7 +111,7 @@ class ServeCommand extends Command
 		$port = $input->getOption('port') ? (int) $input->getOption('port') : 5500;
 		$isDockerProject = file_exists(getcwd() . '/docker-compose.yml');
 		$process = Process::fromShellCommandline(
-			$isDockerProject ? 'docker-compose up' : "php -S localhost:$port",
+			$isDockerProject ? 'docker compose up' : "php -S localhost:$port",
 			null,
 			null,
 			null,


### PR DESCRIPTION
## Description

- As per docker documentation: "Compose V1 no longer receives updates and will not be available in new releases of Docker Desktop after June 2023. Update scripts to use Compose V2 by replacing the hyphen (-) with a space, using docker compose instead of docker-compose."